### PR TITLE
Convert `Map`s to JSON objects

### DIFF
--- a/library/Hpack/Dhall.hs
+++ b/library/Hpack/Dhall.hs
@@ -48,7 +48,8 @@ import Dhall.Core (Expr)
 import Dhall.Parser (Src, exprFromText)
 import Dhall.Import (loadWith, emptyStatus)
 import Dhall.TypeCheck (typeOf)
-import Dhall.JSON (dhallToJSON, omitNull)
+import Dhall.JSON
+    (convertToHomogeneousMaps, defaultConversion, dhallToJSON, omitNull)
 import Dhall.Pretty (prettyExpr, layoutOpts)
 import qualified Prettyprinter as PP
 import qualified Prettyprinter.Render.Text as PP
@@ -129,7 +130,9 @@ textToJson
 textToJson settings text = runExceptT $ do
     expr <- liftIO $ check settings text
     _ <- liftResult $ typeOf expr
-    liftResult $ ([],) . omitNull <$> dhallToJSON expr
+    liftResult $
+      ([],) . omitNull
+        <$> dhallToJSON (convertToHomogeneousMaps defaultConversion expr)
     where
         liftResult :: (Show b, Monad m) => Either b a -> ExceptT String m a
         liftResult = ExceptT . return . first show


### PR DESCRIPTION
There’s no place in hpack where `mapName` or `mapValue` can be used as object keys inside a list, so it’s safe to convert those instances to JSON objects, rather than a literal translation to an array of objects.

This is especially helpful when trying to typecheck hpack-dhall values, because while writing `tests.foo = {=}` is perfectly fine, it has a different type than `tests.bar = {=}`. However, `tests = toMap { foo = {=} }` and `tests = toMap { bar = {=} }` have the same type.

After this change, the two variants above (`tests.foo` and `tests = toMap { foo … }`) convert to the same JSON.

Also after this, I’ve been able to write [consistent types for all of hpack-dhall](https://github.com/sellout/hall/tree/typed-hpack/dhall/hpack), which has allowed me to define Dhall schemas and abstract a few other things in my package.dhall files, like [autogenerating the `license-file` list](https://github.com/sellout/hpack-dhall-defaults/blob/typed-hpack/dhall/Package/License/package.dhall#L21-L34)